### PR TITLE
feat(docker): use maven to build project and use distroless java to run it

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,12 +1,10 @@
-FROM amazoncorretto:17 AS builder
-WORKDIR /app
-COPY . .
-RUN javac -d target src/main/java/org/javadegree/Main.java \
-        src/main/java/org/javadegree/consumer/*.java \
-        src/main/java/org/javadegree/producer/*.java \
-        src/main/java/org/javadegree/producerconsumer/*.java
+# syntax=docker/dockerfile:1
 
-FROM amazoncorretto:17
-WORKDIR /app
-COPY --from=builder /app/target .
-CMD ["java", "org.javadegree.Main"]
+FROM maven:3.9-amazoncorretto-17 AS builder
+COPY src /usr/src/app/src
+COPY pom.xml /usr/src/app
+RUN mvn -f /usr/src/app/pom.xml clean package
+
+FROM gcr.io/distroless/java17:latest
+COPY --from=builder /usr/src/app/target/JavaDegree.jar /usr/app/JavaDegree.jar
+ENTRYPOINT ["java", "-jar", "/usr/app/JavaDegree.jar"]

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,6 +7,37 @@
     <groupId>org.javadegree</groupId>
     <artifactId>java</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <build>
+        <finalName>JavaDegree</finalName>
+        <plugins>
+            <plugin>
+                <!-- https://maven.apache.org/plugins/maven-assembly-plugin/usage.html -->
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.javadegree.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
De gros changements dans le `pom.xml` et sur le `Dockerfile` qui n'utilisait pas Maven ; on aurait pas pu utiliser la lib Kafka de fait, car installé par Maven.
J'ai aussi ajouté le multistage build pour ne pas mettre le code source dans l'image comme semblait souhaiter M. LOGÉ. Du coup je fais porter un `.jar` créé via un plugin Maven (voir `pom.xml`) par une image distroless Java 17, et plus par Amazon Corretto qui n'est utilisé que pour le build ; ce qui évite de trimbaler tout le SDK inutile dans l'image.

<br />

Pour créer le package JAR il faut utiliser :
https://maven.apache.org/plugins/maven-assembly-plugin/usage.html
plutôt que :
https://maven.apache.org/plugins/maven-jar-plugin/plugin-info.html

<br />

J'ai utilisé une distroless Java de GCP :
https://console.cloud.google.com/gcr/images/distroless